### PR TITLE
Data pipeline fixes for full datasets pickle generation

### DIFF
--- a/data/params_french.json
+++ b/data/params_french.json
@@ -1,7 +1,7 @@
 {
     "path_params": {
         "ts_filename": "data/FrenchPiezo/dataset_2015_2021.csv",
-        "ctx_filename": "`data/FrenchPiezo/dataset_stations.csv",
+        "ctx_filename": "data/FrenchPiezo/dataset_stations.csv",
         "ex_filename": ""
     },
 

--- a/data_step.py
+++ b/data_step.py
@@ -86,8 +86,8 @@ def main(path_params: dict, prep_params: dict, eval_params: dict, seed: int = 42
         for stn, scaler in scalers.items()
     }
 
-
-    exg_cols = exg_cols + (exg_params['features_stn'] if 'features_stn' in exg_params else [])
+    features_stn = exg_params['features_stn'] if 'features_stn' in exg_params else []
+    exg_cols = exg_cols + features_stn
     cols = [label_col] + exg_cols
 
     time_feats = ts_params["time_feats"]
@@ -171,10 +171,13 @@ def main(path_params: dict, prep_params: dict, eval_params: dict, seed: int = 42
     for x in arr_list:
         nan += x[:, :, 1].sum().sum()
         tot += x[:, :, 1].size
-    tot -= tot * len(exg_params["features_stn"]) / (len(exg_cols)+1)
+    tot -= tot * len(features_stn) / (len(exg_cols)+1)
     print(f"Missing values in windows (excluding static features): {int(nan)}/{int(tot)} ({nan/tot:.2%})")
 
-    pickle_path = os.path.join('./pickles', f"{conf_name}.pickle")
+    pickles_dir = os.path.join('.', 'pickles')
+    os.makedirs(pickles_dir, exist_ok=True)
+
+    pickle_path = os.path.join(pickles_dir, f"{conf_name}.pickle")
     with open(pickle_path, "wb") as f:
         print('Saving to', pickle_path, '...', end='', flush=True)
         pickle.dump(D, f)

--- a/istf/dataset/ushcn/read.py
+++ b/istf/dataset/ushcn/read.py
@@ -79,7 +79,7 @@ def load_ushcn_data(
     ctx_dict = extract_ushcn_context(
         filename=ts_filename,
         id_col='COOP_ID',
-        x_col='X', y_col='Y'
+        x_col='LONGITUDE', y_col='LATITUDE'
     )
 
     # Remove time-series without context information


### PR DESCRIPTION
This pull request introduces several improvements and fixes:

1. params_french.json
    - Fixed a typo in the "ctx_filename" value by removing an unwanted backtick character.
data_step.py

2. Refactored the handling of the features_stn parameter for clarity and robustness.
3. Enhanced the pickling process: now ensures the pickles directory exists before saving, to prevent errors if the directory is missing.
4. istf/dataset/ushcn/read.py
    - Changed context extraction to use "LONGITUDE" and "LATITUDE" columns instead of "X" and "Y" for better clarity and accuracy in geo-coordinates.


These changes improve code clarity, robustness, and ensure correct handling of file paths and context columns.